### PR TITLE
Permission expiry timezones

### DIFF
--- a/src/main/java/com/databasepreservation/common/api/v1/DatabaseResource.java
+++ b/src/main/java/com/databasepreservation/common/api/v1/DatabaseResource.java
@@ -330,8 +330,10 @@ public class DatabaseResource implements DatabaseService {
     } catch (DateTimeException e) {
       zoneId = ZoneOffset.UTC;
     }
+    // LocalDateTime gets the current time in the configured timezone...
     LocalDateTime nowDateTime = LocalDateTime.ofInstant(new Date().toInstant(), zoneId);
-    Date now = Date.from(nowDateTime.atZone(zoneId).toInstant());
+    // ... and then we convert to Date using UTC so that it is sent to the query with the timezone's offset
+    Date now = Date.from(nowDateTime.atZone(ZoneOffset.UTC).toInstant());
 
     BlockJoinAnyParentExpiryFilterParameter param = new BlockJoinAnyParentExpiryFilterParameter(user.getAllRoles(), now,
       null);

--- a/src/main/java/com/databasepreservation/common/api/v1/DatabaseResource.java
+++ b/src/main/java/com/databasepreservation/common/api/v1/DatabaseResource.java
@@ -8,9 +8,10 @@
 package com.databasepreservation.common.api.v1;
 
 import java.io.IOException;
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -321,13 +322,19 @@ public class DatabaseResource implements DatabaseService {
   public static List<Filter> getDatabaseFindUserPermissionsFilterQueries(User user) {
     Filter filter = new Filter();
 
-    // Convert today's date to midnight, start of the day
-    LocalDateTime now = LocalDateTime.ofInstant(new Date().toInstant(), ZoneId.systemDefault());
-    LocalDateTime today = now.with(LocalTime.MIN);
-    Date todayDate = Date.from(today.atZone(ZoneId.systemDefault()).toInstant());
+    String zoneIdString = ViewerConfiguration.getInstance().getViewerConfigurationAsString("UTC",
+      ViewerConstants.PROPERTY_EXPIRY_ZONE_ID_OVERRIDE);
+    ZoneId zoneId;
+    try {
+      zoneId = ZoneId.of(zoneIdString);
+    } catch (DateTimeException e) {
+      zoneId = ZoneOffset.UTC;
+    }
+    LocalDateTime nowDateTime = LocalDateTime.ofInstant(new Date().toInstant(), zoneId);
+    Date now = Date.from(nowDateTime.atZone(zoneId).toInstant());
 
-    BlockJoinAnyParentExpiryFilterParameter param = new BlockJoinAnyParentExpiryFilterParameter(user.getAllRoles(),
-      todayDate, null);
+    BlockJoinAnyParentExpiryFilterParameter param = new BlockJoinAnyParentExpiryFilterParameter(user.getAllRoles(), now,
+      null);
     filter.add(param);
     return new ArrayList<>(List.of(filter));
   }

--- a/src/main/java/com/databasepreservation/common/client/ViewerConstants.java
+++ b/src/main/java/com/databasepreservation/common/client/ViewerConstants.java
@@ -593,7 +593,7 @@ public class ViewerConstants {
   /**
    * Permissions
    */
-  public static final String PROPERTY_EXPIRY_ZONE_ID_OVERRIDE = "ui.permissions.expiry.zoneId.override";
+  public static final String PROPERTY_EXPIRY_ZONE_ID_OVERRIDE = "permissions.expiry.zoneId.override";
 
   /**
    * Header

--- a/src/main/java/com/databasepreservation/common/client/ViewerConstants.java
+++ b/src/main/java/com/databasepreservation/common/client/ViewerConstants.java
@@ -591,6 +591,11 @@ public class ViewerConstants {
   public static final String PROPERTY_SEARCH_ALL_DEFAULT_SELECTION = "ui.searchAll.defaultSelection";
 
   /**
+   * Permissions
+   */
+  public static final String PROPERTY_EXPIRY_ZONE_ID_OVERRIDE = "ui.permissions.expiry.zoneId.override";
+
+  /**
    * Header
    */
   public static final String DEFAULT_PROPERTY_UI_HEADER_TITLE = "<img src=\"api/v1/theme?resource_id=dbptk_logo_white_vector.svg\" class=\"header-logo\"><span class=\"header-text\">DBPTK Enterprise</span>";

--- a/src/main/java/com/databasepreservation/common/client/common/visualization/manager/SIARDPanel/navigation/PermissionsNavigationPanel.java
+++ b/src/main/java/com/databasepreservation/common/client/common/visualization/manager/SIARDPanel/navigation/PermissionsNavigationPanel.java
@@ -76,7 +76,8 @@ public class PermissionsNavigationPanel {
 
   private AuthorizationGroup currentGroup;
   private DateTimeFormat htmlInputPresentedDateFormat = DateTimeFormat.getFormat("MM/dd/yyyy");
-  private DateTimeFormat htmlInputDateFormat = DateTimeFormat.getFormat("yyyy-MM-dd");
+  private DateTimeFormat htmlMinDateFormat = DateTimeFormat.getFormat("yyyy-MM-dd");
+  private DateTimeFormat htmlInputDateFormat = DateTimeFormat.getFormat("yyyy-MM-ddTHH:mm:ssZ");
   private Date lastDate;
 
   private boolean overrideMissingGroups = false;
@@ -316,7 +317,7 @@ public class PermissionsNavigationPanel {
   }
 
   private void showDatePicker() {
-    String today = htmlInputDateFormat.format(new Date());
+    String today = htmlMinDateFormat.format(new Date());
     String currentDateValueAttribute = "";
     if (groupDetails.getOrDefault(currentGroup.getAttributeValue(), new AuthorizationDetails()).hasExpiryDate()) {
       currentDateValueAttribute = "value=\""
@@ -329,7 +330,7 @@ public class PermissionsNavigationPanel {
         super.onDetach();
         String datePickerValue = JavascriptUtils.getInputValue("expiryDatePicker");
         if (datePickerValue != null && !datePickerValue.isEmpty()) {
-          lastDate = htmlInputDateFormat.parse(datePickerValue);
+          lastDate = htmlInputDateFormat.parse(datePickerValue + "T23:59:59-0000");
         } else {
           lastDate = null;
         }

--- a/src/main/resources/config/dbvtk-viewer.properties
+++ b/src/main/resources/config/dbvtk-viewer.properties
@@ -17,7 +17,6 @@ ui.sharedProperties.whitelist.configuration.prefix=ui.plugin
 ui.sharedProperties.whitelist.configuration.prefix=ui.siard
 ui.sharedProperties.whitelist.configuration.prefix=ui.reference
 ui.sharedProperties.whitelist.configuration.prefix=ui.searchAll
-ui.sharedProperties.whitelist.configuration.prefix=ui.permissions
 ui.sharedProperties.whitelist.configuration.property=lists
 ui.sharedProperties.whitelist.configuration.property=ui.lists
 ui.sharedProperties.whitelist.messages.prefix=ui.facets
@@ -220,9 +219,9 @@ ui.searchAll.defaultSelection=all
 
 ##############################################
 # Permission expiry settings
-# ui.permissions.expiry.zoneId.override
+# permissions.expiry.zoneId.override
 #    The timezone that the server uses to calculate the current date and time when querying for permission expiry dates.
 #    Default: "UTC"
 #    Possible values: Any valid Java ZoneId string
 ##############################################
-ui.permissions.expiry.zoneId.override=UTC
+permissions.expiry.zoneId.override=UTC

--- a/src/main/resources/config/dbvtk-viewer.properties
+++ b/src/main/resources/config/dbvtk-viewer.properties
@@ -17,6 +17,7 @@ ui.sharedProperties.whitelist.configuration.prefix=ui.plugin
 ui.sharedProperties.whitelist.configuration.prefix=ui.siard
 ui.sharedProperties.whitelist.configuration.prefix=ui.reference
 ui.sharedProperties.whitelist.configuration.prefix=ui.searchAll
+ui.sharedProperties.whitelist.configuration.prefix=ui.permissions
 ui.sharedProperties.whitelist.configuration.property=lists
 ui.sharedProperties.whitelist.configuration.property=ui.lists
 ui.sharedProperties.whitelist.messages.prefix=ui.facets
@@ -216,3 +217,12 @@ ui.iiif_viewer.presentation.service_name=presentation
 #    Possible values: "all" (search on all available databases), "none" (search on no databases)
 ##############################################
 ui.searchAll.defaultSelection=all
+
+##############################################
+# Permission expiry settings
+# ui.permissions.expiry.zoneId.override
+#    The timezone that the server uses to calculate the current date and time when querying for permission expiry dates.
+#    Default: "UTC"
+#    Possible values: Any valid Java ZoneId string
+##############################################
+ui.permissions.expiry.zoneId.override=UTC


### PR DESCRIPTION
- Expiry dates are now stores as the last second of the specified date, forcing UTC to ignore client's timezone
- When querying for permission expiry dates, the dates are considered to be in a configured timezone or UTC by default
  - e.g., admin selects 17/12/2024 in UI -> Solr stores expiry as `17/12/2024T23:59:59Z`; user tries to access that database -> query checks if the current time in the configured timezone is after `17/12/2024T23:59:59Z`
