### PR TITLE
Tristate checkboxes for permission expiries

### DIFF
--- a/src/main/java/com/databasepreservation/common/client/common/lists/TableRowList.java
+++ b/src/main/java/com/databasepreservation/common/client/common/lists/TableRowList.java
@@ -232,7 +232,7 @@ public class TableRowList extends AsyncTableCell<ViewerRow, TableRowListWrapper>
         if (row.getNestedRowList() != null) {
           for (ViewerRow nestedRow : row.getNestedRowList()) {
             if (nestedRow != null && nestedRow.getCells() != null && !nestedRow.getCells().isEmpty()
-              && nestedRow.getUuid().equals(configColumn.getId())) {
+              && nestedRow.getNestedUUID().equals(configColumn.getId())) {
               Map<String, ViewerCell> cells = nestedRow.getCells();
 
               // removes the nested prefix of the nested collumn

--- a/src/main/java/com/databasepreservation/common/client/common/search/panel/NestedSearchFieldPanel.java
+++ b/src/main/java/com/databasepreservation/common/client/common/search/panel/NestedSearchFieldPanel.java
@@ -9,6 +9,7 @@ package com.databasepreservation.common.client.common.search.panel;
 
 import java.util.List;
 
+import com.databasepreservation.common.client.ViewerConstants;
 import com.databasepreservation.common.client.common.search.SearchField;
 import com.databasepreservation.common.client.index.filter.BlockJoinParentFilterParameter;
 import com.databasepreservation.common.client.index.filter.FilterParameter;
@@ -39,7 +40,7 @@ public class NestedSearchFieldPanel extends SearchFieldPanel {
     List<String> searchFields = getSearchField().getSearchFields();
 
     if (searchFields != null && searchFields.size() >= 1) {
-      String field = searchFields.get(0);
+      String field = ViewerConstants.SOLR_ROWS_NESTED_COL + searchFields.get(0);
       if (!inputText.getValue().isEmpty()) {
         filterParameter = new BlockJoinParentFilterParameter(field, inputText.getValue(), searchFields.get(1),
           searchFields.get(2));

--- a/src/main/java/com/databasepreservation/common/client/common/utils/JavascriptUtils.java
+++ b/src/main/java/com/databasepreservation/common/client/common/utils/JavascriptUtils.java
@@ -354,4 +354,9 @@ public class JavascriptUtils {
                                                                                 var element = $wnd.jQuery("#" + elementId);
                                                                                 element.removeAttr(attribute);
                                                                                 }-*/;
+
+  public static native void setIndeterminate(String checkboxesJQuery) /*-{
+                                                                          var checkboxes = $wnd.jQuery(checkboxesJQuery);
+                                                                          checkboxes.prop("indeterminate", true);
+                                                                          }-*/;
 }

--- a/src/main/java/com/databasepreservation/common/client/common/visualization/manager/SIARDPanel/navigation/PermissionsNavigationPanel.java
+++ b/src/main/java/com/databasepreservation/common/client/common/visualization/manager/SIARDPanel/navigation/PermissionsNavigationPanel.java
@@ -39,12 +39,14 @@ import com.databasepreservation.common.client.widgets.Toast;
 import com.google.gwt.cell.client.Cell;
 import com.google.gwt.cell.client.CheckboxCell;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.i18n.client.TimeZone;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.cellview.client.Column;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.FlowPanel;
@@ -234,6 +236,17 @@ public class PermissionsNavigationPanel {
       public Boolean getValue(AuthorizationGroup group) {
         return databasePermissionGroups.contains(group.getAttributeValue());
       }
+
+      @Override
+      public String getCellStyleNames(Cell.Context context, AuthorizationGroup group) {
+        if (groupDetails.getOrDefault(group.getAttributeValue(), new AuthorizationDetails()).hasExpiryDate()) {
+          Date now = new Date();
+          if (now.after(groupDetails.get(group.getAttributeValue()).getExpiry())) {
+            return "expired";
+          }
+        }
+        return "";
+      }
     };
 
     checkbox.setFieldUpdater((index, group, value) -> {
@@ -242,6 +255,7 @@ public class PermissionsNavigationPanel {
         if (!databasePermissionGroups.contains(group.getAttributeValue())) {
           databasePermissionGroups.add(group.getAttributeValue());
         }
+        deferSetIndeterminateCheckboxes();
       } else {
         // Remove
         databasePermissionGroups.remove(group.getAttributeValue());
@@ -378,6 +392,7 @@ public class PermissionsNavigationPanel {
             }
             groupDetails.put(currentGroup.getAttributeValue(), authorizationDetails);
             cellTable.refresh();
+            deferSetIndeterminateCheckboxes();
           }
         }
       });
@@ -421,6 +436,7 @@ public class PermissionsNavigationPanel {
       new BasicTablePanel.ColumnInfo<AuthorizationGroup>(
         messages.SIARDHomePageLabelForPermissionsTableGroupExpiryDate(), 12, expiry,
         "force_column_ellipsis expiry_column"));
+    deferSetIndeterminateCheckboxes();
   }
 
   private void doSearch(String searchValue, FlowPanel permissionListPanel) {
@@ -476,5 +492,13 @@ public class PermissionsNavigationPanel {
       permissions.put(permission, groupDetails.getOrDefault(permission, new AuthorizationDetails()));
     }
     return permissions;
+  }
+
+  private void deferSetIndeterminateCheckboxes() {
+    Scheduler.get().scheduleDeferred(new Command() {
+      public void execute() {
+        JavascriptUtils.setIndeterminate(".expired input");
+      }
+    });
   }
 }

--- a/src/main/java/com/databasepreservation/common/client/index/filter/BlockJoinParentFilterParameter.java
+++ b/src/main/java/com/databasepreservation/common/client/index/filter/BlockJoinParentFilterParameter.java
@@ -68,6 +68,8 @@ public class BlockJoinParentFilterParameter extends FilterParameter {
   }
 
   @Override
-  public String toString() { return "{!parent which='tableId:" + parentTableId +"' filters='uuid:"+ nestedUUID +"' }" + solrName + ":" + value;
+  public String toString() {
+    return "{!parent which='tableId:" + parentTableId + "' filters='nestedUUID:" + nestedUUID + "' }" + solrName + ":"
+      + value;
   }
 }

--- a/src/main/java/com/databasepreservation/common/server/index/DatabaseRowsSolrManager.java
+++ b/src/main/java/com/databasepreservation/common/server/index/DatabaseRowsSolrManager.java
@@ -624,10 +624,9 @@ public class DatabaseRowsSolrManager {
   public SolrInputDocument createNestedDocument(String uuid, String originalRowUUID, String tableRowUUID,
     Map<String, ?> fields, String tableId, String nestedUUID) {
     SolrInputDocument nestedDoc = new SolrInputDocument();
-    nestedDoc.addField(ViewerConstants.INDEX_ID, uuid);
+    nestedDoc.addField(ViewerConstants.INDEX_ID, SolrUtils.randomUUID());
     nestedDoc.addField(ViewerConstants.SOLR_ROWS_NESTED_UUID, nestedUUID);
     nestedDoc.addField(ViewerConstants.SOLR_ROWS_NESTED_TABLE_ID, tableId);
-    nestedDoc.addField("originalRowUUID_t", originalRowUUID);
     nestedDoc.addField(ViewerConstants.SOLR_ROWS_NESTED_ORIGINAL_UUID, tableRowUUID);
     for (Map.Entry<String, ?> entry : fields.entrySet()) {
       if (entry.getKey().equals(ViewerConstants.SOLR_ROWS_NESTED)) {

--- a/src/main/java/com/databasepreservation/common/server/index/utils/SolrUtils.java
+++ b/src/main/java/com/databasepreservation/common/server/index/utils/SolrUtils.java
@@ -678,7 +678,7 @@ public class SolrUtils {
         + param.getNestedOriginalUUID());
     } else if (parameter instanceof BlockJoinParentFilterParameter) {
       BlockJoinParentFilterParameter param = (BlockJoinParentFilterParameter) parameter;
-      ret.append("+({!parent which='tableId:" + param.getParentTableId() + "' filters='uuid:" + param.getNestedUUID()
+      ret.append("+({!parent which='tableId:" + param.getParentTableId() + "' filters='nestedUUID:" + param.getNestedUUID()
         + "' }" + param.getSolrName() + ":" + param.getValue() + ")");
     } else {
       LOGGER.error("Unsupported filter parameter class: {}", parameter.getClass().getName());


### PR DESCRIPTION
Makes the checkbox for checked groups in a SIARD's permissions panel be set to the indeterminate state if the currently set expiry date has already passed.