### PR TITLE
Potential fix for code scanning alert no. 82: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/databasepreservation/common/api/v1/FileResource.java
+++ b/src/main/java/com/databasepreservation/common/api/v1/FileResource.java
@@ -87,6 +87,10 @@ public class FileResource implements FileService {
 
     try {
       user = controllerAssistant.checkRoles(request);
+      // Validate the filename to ensure it does not contain any path separators or parent directory references
+      if (filename.contains("..") || filename.contains("/") || filename.contains("\\")) {
+        throw new IllegalArgumentException("Invalid filename");
+      }
       java.nio.file.Path siardFilesPath = ViewerConfiguration.getInstance().getSIARDFilesPath();
       java.nio.file.Path basePath = Paths.get(ViewerConfiguration.getInstance().getViewerConfigurationAsString(siardFilesPath.toString(),
         ViewerConfiguration.PROPERTY_BASE_UPLOAD_PATH));


### PR DESCRIPTION
Potential fix for [https://github.com/keeps/dbptk-ui/security/code-scanning/82](https://github.com/keeps/dbptk-ui/security/code-scanning/82)

To fix the problem, we need to validate and sanitize the `filename` parameter in the `getSIARDFile` method before using it to construct the `siardPath`. We should ensure that the `filename` does not contain any path separators or parent directory references. This can be done by checking for the presence of "..", "/", or "\\" in the `filename` and throwing an exception if any are found.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
