### PR TITLE
Potential fix for code scanning alert no. 76: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/com/databasepreservation/common/api/v1/CollectionResource.java
+++ b/src/main/java/com/databasepreservation/common/api/v1/CollectionResource.java
@@ -322,6 +322,9 @@ public class CollectionResource implements CollectionService {
 
     try {
       user = controllerAssistant.checkRoles(request);
+      if (databaseUUID.contains("..") || databaseUUID.contains("/") || databaseUUID.contains("\\")) {
+        throw new IllegalArgumentException("Invalid databaseUUID");
+      }
       Path path = ViewerConfiguration.getInstance().getDatabasesPath().resolve(databaseUUID)
         .resolve(ViewerConstants.DENORMALIZATION_STATUS_PREFIX + tableUUID + ViewerConstants.JSON_EXTENSION);
       if (Files.exists(path)) {


### PR DESCRIPTION
Potential fix for [https://github.com/keeps/dbptk-ui/security/code-scanning/76](https://github.com/keeps/dbptk-ui/security/code-scanning/76)

To fix the problem, we need to validate the `databaseUUID` before using it to construct a file path. We can ensure that the `databaseUUID` does not contain any path separators or parent directory references. This can be done by checking for the existence of any path separators ("/" or "\\") or ".." sequences in the input and rejecting the input if any are found.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
