### PR TITLE
fix: clean up temporary LOB files after each row during indexing

### DIFF
--- a/src/main/java/com/databasepreservation/modules/viewer/DbvtkExportModule.java
+++ b/src/main/java/com/databasepreservation/modules/viewer/DbvtkExportModule.java
@@ -26,6 +26,8 @@ import com.databasepreservation.common.server.ViewerFactory;
 import com.databasepreservation.common.server.index.DatabaseRowsSolrManager;
 import com.databasepreservation.common.server.index.schema.SolrRowsCollectionRegistry;
 import com.databasepreservation.common.transformers.ToolkitStructure2ViewerStructure;
+import com.databasepreservation.model.data.BinaryCell;
+import com.databasepreservation.model.data.Cell;
 import com.databasepreservation.model.data.Row;
 import com.databasepreservation.model.exception.ModuleException;
 import com.databasepreservation.model.exception.UnknownTypeException;
@@ -144,6 +146,12 @@ public class DbvtkExportModule implements DatabaseFilterModule {
   public void handleDataRow(Row row) throws ModuleException {
     solrManager.addRow(collectionConfiguration, ToolkitStructure2ViewerStructure.getRow(collectionConfiguration,
       currentTable, row, rowIndex++, retrieved.getPath(), retrieved.getVersion()));
+
+    for (Cell cell : row.getCells()) {
+      if (cell instanceof BinaryCell) {
+        ((BinaryCell) cell).cleanResources();
+      }
+    }
 
     rowsProcessedByTableCounter++;
     rowCounter++;


### PR DESCRIPTION
## Summary
- `DbvtkExportModule.handleDataRow()` never called `cleanResources()` on `BinaryCell` input stream providers after converting/indexing a row.
- Temp files created via `TemporaryPathInputStreamProvider` (`Files.createTempFile("dbptk", "lob")`) for LOBs embedded in `table.xml` were therefore only removed by JVM shutdown hooks, letting `/tmp` grow to hundreds of gigabytes while indexing SIARDs with many LOBs.
- Added the same per-row cleanup loop already used by `dbptk-developer`'s `SinkModule.handleDataRow()`: iterate the row's cells and call `cleanResources()` on each `BinaryCell` after it has been converted (its content is already read/copied into the row sent to Solr by `ToolkitStructure2ViewerStructure.getRow()`, so this is safe). `PathInputStreamProvider.cleanResources()` (used for externally-stored LOBs) is a no-op, so external LOB files are left untouched.

Fixes #638

## Test plan
- [x] `mvn compile` succeeds
- [x] Index a SIARD with many embedded LOBs and confirm `/tmp/dbptk*lob` files no longer accumulate during indexing (only transient per-row temp files should exist at any time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)